### PR TITLE
Add configuration for Chainguard Enforce

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -1,0 +1,10 @@
+---
+spec:
+  authorities:
+    # Accept all keyless signatures validated from the public sigstore instance.
+    # This is open source software after all. All we want to know is that the
+    # person that did the commit has control over their email address.
+    - keyless:
+    # Add this if you also want to allow commits signed by GitHub.
+    - key:
+        kms: https://github.com/web-flow.gpg


### PR DESCRIPTION
#### What does this PR do

Chainguard Enforce is a GitHub app that verifies container signatures.
It's able to verify signatures using Sigstore's keyless signing as well
as GPG keys. This is already set up and working in the [audit event
library](https://github.com/metal-toolbox/auditevent).

The provided configuration will verify that folks are using sigstore's
keyless signatures on their commits, and will also accept GitHub API's
GPG keys to have apps like renovate have valid signatures.

To set up keyless signatures, use gitsign [1]. If on mac, you may
install it as follows:

```bash
brew install sigstore/tap/gitsign
```

And set it up in this repository only:

```bash
cd /path/to/this/repository
git config --local commit.gpgsign true  # Sign all commits
git config --local tag.gpgsign true  # Sign all tags
git config --local gpg.x509.program gitsign  # Use gitsign for signing
git config --local gpg.format x509  # gitsign expects x509 args
```

This shouldn't be set for all repositories as it will add references to
the repositories and branches o a public transparency log, which you
don't want in a private or internal GitHub repository.

[1] https://github.com/sigstore/gitsign

#### The HW vendor this change applies to (if applicable)

None

#### The HW model number, product name this change applies to (if applicable)

None

#### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

None

#### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

None

#### How can this change be tested by a PR reviewer?
