### PR TITLE
Add instructions for setting up gitsign

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -5,6 +5,7 @@ spec:
     # This is open source software after all. All we want to know is that the
     # person that did the commit has control over their email address.
     - keyless:
+        url: https://fulcio.sigstore.dev
     # Add this if you also want to allow commits signed by GitHub.
     - key:
         kms: https://github.com/web-flow.gpg

--- a/README.md
+++ b/README.md
@@ -141,3 +141,17 @@ FLAGS
 
 flag: help requested
 ```
+
+##### Developing Alloy
+
+Alloy now requires signed commits which are attested via [sigstore](https://www.sigstore.dev/).
+To enable that in your development machine, you need to install [gitsign](https://github.com/sigstore/gitsign)
+and enable commit signing with it for this repository:
+
+```bash
+cd /path/to/this/repository
+git config --local commit.gpgsign true  # Sign all commits
+git config --local tag.gpgsign true  # Sign all tags
+git config --local gpg.x509.program gitsign  # Use gitsign for signing
+git config --local gpg.format x509  # gitsign expects x509 args
+```


### PR DESCRIPTION
#### What does this PR do

Now that Chainguard Enforce is running on this repository, this now adds
instructions to the README.

