### PR TITLE
Point the chainguard plugin to the public sigstore instance

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -5,6 +5,7 @@ spec:
     # This is open source software after all. All we want to know is that the
     # person that did the commit has control over their email address.
     - keyless:
+        url: https://fulcio.sigstore.dev
     # Add this if you also want to allow commits signed by GitHub.
     - key:
         kms: https://github.com/web-flow.gpg


### PR DESCRIPTION
#### What does this PR do

Apparently empty wasn't a good default and we should explicitly point it
to the public fulcio instance.
