### PR TITLE
cmd/inband: get inventory asset when --asset-source is specified

### DIFF
--- a/cmd/inband.go
+++ b/cmd/inband.go
@@ -135,18 +135,30 @@ func (i *inbandCmd) Exec(ctx context.Context, _ []string) error {
 			}
 		}()
 
-		device, err := collector.InventoryLocal(ctx)
+		collected, err := collector.InventoryLocal(ctx)
 		if err != nil {
 			alloy.Logger.Error(err)
 		}
 
-		device.ID = i.assetID
+		collected.ID = i.assetID
+
+		// set collected inventory attributes based on inventory data
+		// so as to not overwrite any of these existing values when published.
 		if inventoryAsset != nil {
-			device.Model = inventoryAsset.Model
-			device.Vendor = inventoryAsset.Vendor
+			if inventoryAsset.Model != "" {
+				collected.Model = inventoryAsset.Model
+			}
+
+			if inventoryAsset.Vendor != "" {
+				collected.Vendor = inventoryAsset.Vendor
+			}
+
+			if inventoryAsset.Serial != "" {
+				collected.Serial = inventoryAsset.Serial
+			}
 		}
 
-		err = publisher.PublishOne(ctx, device)
+		err = publisher.PublishOne(ctx, collected)
 		if err != nil {
 			alloy.Logger.Error(err)
 		}

--- a/internal/collect/inband.go
+++ b/internal/collect/inband.go
@@ -55,6 +55,8 @@ func (i *InbandCollector) InventoryLocal(ctx context.Context) (*model.Asset, err
 
 	device.Vendor = common.FormatVendorName(device.Vendor)
 
+	// The "unknown" valued attributes here are to be filled in by the caller,
+	// with the data from the inventory source when its available.
 	return &model.Asset{Inventory: device, Vendor: "unknown", Model: "unknown", Serial: "unknown"}, nil
 }
 

--- a/internal/publish/serverservice_attributes.go
+++ b/internal/publish/serverservice_attributes.go
@@ -28,9 +28,7 @@ func (h *serverServicePublisher) createUpdateServerAttributes(ctx context.Contex
 	}
 
 	// create, when current asset in the inventory has no serial vendor, model attributes set
-	if asset.Serial == "unknown" &&
-		asset.Vendor == "unknown" &&
-		asset.Model == "unknown" {
+	if vendorModelSerialUnknown(asset) {
 		attribute := serverservice.Attributes{
 			Namespace: model.ServerVendorAttributeNS,
 			Data:      attributesData,
@@ -44,11 +42,10 @@ func (h *serverServicePublisher) createUpdateServerAttributes(ctx context.Contex
 		return nil
 	}
 
-	// update, when attributes are set but don't match
-	if asset.Serial != asset.Inventory.Serial ||
-		asset.Vendor != asset.Inventory.Vendor ||
-		asset.Model != asset.Inventory.Model {
-		// update vendor, model attributes
+	// update when these attributes are empty in serverservice
+	if (asset.Serial != "" && asset.Inventory.Serial == "") ||
+		(asset.Vendor != "" && asset.Inventory.Vendor == "") ||
+		(asset.Model != "" && asset.Inventory.Model == "") {
 		_, err = h.client.UpdateAttributes(ctx, serverID, model.ServerVendorAttributeNS, attributesData)
 		if err != nil {
 			return err
@@ -56,6 +53,10 @@ func (h *serverServicePublisher) createUpdateServerAttributes(ctx context.Contex
 	}
 
 	return nil
+}
+
+func vendorModelSerialUnknown(asset *model.Asset) bool {
+	return asset.Serial == "unknown" && asset.Vendor == "unknown" && asset.Model == "unknown"
 }
 
 // createUpdateServerMetadataAttributes creates/updates metadata attributes of a server

--- a/internal/publish/serverservice_attributes.go
+++ b/internal/publish/serverservice_attributes.go
@@ -80,11 +80,7 @@ func (h *serverServicePublisher) createUpdateServerMetadataAttributes(ctx contex
 	// current asset metadata has no attributes set, create
 	if len(asset.Metadata) == 0 {
 		_, err = h.client.CreateAttributes(ctx, serverID, attribute)
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return err
 	}
 
 	// update when metadata differs
@@ -94,11 +90,8 @@ func (h *serverServicePublisher) createUpdateServerMetadataAttributes(ctx contex
 
 	// update vendor, model attributes
 	_, err = h.client.UpdateAttributes(ctx, serverID, model.ServerMetadataAttributeNS, metadata)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }
 
 // createUpdateServerMetadataAttributes creates/updates metadata attributes of a server


### PR DESCRIPTION
Instead of attempting to query the asset-source each time only query the asset source when the flag is passed in,
This allows alloy to be run on a host without requiring an asset-source to be available.

The change also prevents assets from being published to serverService when --asset-source was not set to serverService.