### PR TITLE
[FS-483] Get BIOS cfg during inband inventory collection

### DIFF
--- a/cmd/inband.go
+++ b/cmd/inband.go
@@ -138,6 +138,9 @@ func (i *inbandCmd) Exec(ctx context.Context, _ []string) error {
 		collected, err := collector.InventoryLocal(ctx)
 		if err != nil {
 			alloy.Logger.Error(err)
+			// returning early here because collected is nil, otherwise I get a nil pointer exception.
+			// not sure if this is correct to do inside this closure
+			return
 		}
 
 		collected.ID = i.assetID

--- a/cmd/inband.go
+++ b/cmd/inband.go
@@ -138,8 +138,6 @@ func (i *inbandCmd) Exec(ctx context.Context, _ []string) error {
 		collected, err := collector.InventoryLocal(ctx)
 		if err != nil {
 			alloy.Logger.Error(err)
-			// returning early here because collected is nil, otherwise I get a nil pointer exception.
-			// not sure if this is correct to do inside this closure
 			return
 		}
 

--- a/internal/collect/inband.go
+++ b/internal/collect/inband.go
@@ -53,11 +53,16 @@ func (i *InbandCollector) InventoryLocal(ctx context.Context) (*model.Asset, err
 		return nil, err
 	}
 
+	biosConfig, err := i.deviceManager.GetBIOSConfiguration(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	device.Vendor = common.FormatVendorName(device.Vendor)
 
 	// The "unknown" valued attributes here are to be filled in by the caller,
 	// with the data from the inventory source when its available.
-	return &model.Asset{Inventory: device, Vendor: "unknown", Model: "unknown", Serial: "unknown"}, nil
+	return &model.Asset{Inventory: device, BiosConfig: biosConfig, Vendor: "unknown", Model: "unknown", Serial: "unknown"}, nil
 }
 
 // InventoryRemote implements is present here to satisfy the Collector interface.

--- a/internal/collect/inband.go
+++ b/internal/collect/inband.go
@@ -37,7 +37,7 @@ func (i *InbandCollector) SetMockGetter(getter interface{}) {
 	i.mock = true
 }
 
-// InventoryLocal implements the Collector interface to collect inventory locally (inband).
+// InventoryLocal implements the Collector interface to collect inventory and bios configuration locally (inband).
 func (i *InbandCollector) InventoryLocal(ctx context.Context) (*model.Asset, error) {
 	if !i.mock {
 		var err error

--- a/internal/collect/interface.go
+++ b/internal/collect/interface.go
@@ -13,7 +13,7 @@ type Collector interface {
 	// the collected inventory is then sent on the collector channel to be published.
 	InventoryRemote(ctx context.Context) error
 
-	// InventoryLocal collects and returns inventory on the local host for the given asset.
+	// InventoryLocal collects and returns inventory and bios configuration on the local host for the given asset.
 	InventoryLocal(ctx context.Context) (*model.Asset, error)
 
 	// SetMockGetter sets a mock device inventory getter to be used for tests.

--- a/internal/fixtures/ironlib.go
+++ b/internal/fixtures/ironlib.go
@@ -28,3 +28,7 @@ func (m *MockIronlib) SetMockDevice(d *common.Device) {
 func (m *MockIronlib) GetInventory(ctx context.Context, dynamic bool) (*common.Device, error) {
 	return m.device, nil
 }
+
+func (m *MockIronlib) GetBIOSConfiguration(ctx context.Context) (biosConfig map[string]string, err error) {
+	return biosConfig, nil
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -33,6 +33,8 @@ type Asset struct {
 	Inventory *common.Device
 	// The device metadata attribute
 	Metadata map[string]string
+	// BIOS configuration
+	BiosConfig map[string]string
 	// The device ID from the inventory store
 	ID string
 	// The device vendor attribute

--- a/internal/model/serverservice.go
+++ b/internal/model/serverservice.go
@@ -25,9 +25,6 @@ const (
 	// errors that occurred when connecting/collecting inventory from the bmc are stored here.
 	ServerBMCErrorsAttributeNS = ServerServiceNSPrefix + ".server_bmc_errors"
 
-	// BIOS configuration is stored in this namespace.
-	ServerBIOSConfigNS = "net.platformequinix.bios"
-
 	// server service server serial attribute key
 	ServerSerialAttributeKey = "serial"
 
@@ -37,6 +34,15 @@ const (
 	// server service server vendor attribute key
 	ServerVendorAttributeKey = "vendor"
 )
+
+// ServerBIOSConfigNS returns the namespace server bios configuration are stored in.
+func ServerBIOSConfigNS(appKind string) string {
+	if biosConfigNS := os.Getenv("SERVERSERVICE_BIOS_CONFIG_NS"); biosConfigNS != "" {
+		return biosConfigNS
+	}
+
+	return fmt.Sprintf("%s.%s.bios_configuration", ServerServiceNSPrefix, appKind)
+}
 
 // ServerServiceAttributeNS returns the namespace server component attributes are stored in.
 func ServerComponentAttributeNS(appKind string) string {

--- a/internal/model/serverservice.go
+++ b/internal/model/serverservice.go
@@ -25,6 +25,9 @@ const (
 	// errors that occurred when connecting/collecting inventory from the bmc are stored here.
 	ServerBMCErrorsAttributeNS = ServerServiceNSPrefix + ".server_bmc_errors"
 
+	// BIOS configuration is stored in this namespace.
+	ServerBIOSConfigNS = "net.platformequinix.bios"
+
 	// server service server serial attribute key
 	ServerSerialAttributeKey = "serial"
 

--- a/internal/publish/serverservice.go
+++ b/internal/publish/serverservice.go
@@ -243,6 +243,15 @@ func (h *serverServicePublisher) publish(ctx context.Context, device *model.Asse
 				"err": err,
 			}).Warn("error converting device object")
 	}
+
+	err = h.createUpdateServerBIOSConfiguration(ctx, server.UUID, device.BiosConfig)
+	if err != nil {
+		h.logger.WithFields(
+			logrus.Fields{
+				"id":  server.UUID.String(),
+				"err": err,
+			}).Warn("error in server bios configuration versioned attribute update")
+	}
 }
 
 // createUpdateServerComponents compares the current object in serverService with the device data and creates/updates server component data.

--- a/internal/publish/serverservice_attributes.go
+++ b/internal/publish/serverservice_attributes.go
@@ -153,6 +153,26 @@ func (h *serverServicePublisher) createUpdateServerMetadataAttributes(ctx contex
 	return err
 }
 
+func (h *serverServicePublisher) createUpdateServerBIOSConfiguration(ctx context.Context, serverID uuid.UUID, biosConfig map[string]string) error {
+	// marshal metadata from device
+	bc, err := json.Marshal(biosConfig)
+	if err != nil {
+		return err
+	}
+
+	va := serverservice.VersionedAttributes{
+		Namespace: model.ServerBIOSConfigNS,
+		Data:      bc,
+	}
+
+	_, err = h.client.CreateVersionedAttributes(ctx, serverID, va)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // createUpdateServerMetadataAttributes creates/updates metadata attributes of a server
 // nolint:gocyclo // (joel) theres a bunch of validation going on here, I'll split the method out if theres more to come.
 func (h *serverServicePublisher) createUpdateServerBMCErrorAttributes(ctx context.Context, serverID uuid.UUID, current *serverservice.Attributes, asset *model.Asset) error {

--- a/internal/publish/serverservice_attributes.go
+++ b/internal/publish/serverservice_attributes.go
@@ -161,7 +161,7 @@ func (h *serverServicePublisher) createUpdateServerBIOSConfiguration(ctx context
 	}
 
 	va := serverservice.VersionedAttributes{
-		Namespace: model.ServerBIOSConfigNS,
+		Namespace: model.ServerBIOSConfigNS(h.config.AppKind),
 		Data:      bc,
 	}
 


### PR DESCRIPTION
#### What does this PR do

During inband inventory collection, also collects BIOS configuration via ironlib.GetBIOSConfiguration()

#### The HW vendor this change applies to (if applicable)

#### The HW model number, product name this change applies to (if applicable)

#### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

#### What version of tooling - vendor specific or opensource does this change depend on (if applicable)
supermicro sum utility 2.10.0 (updated here: https://github.com/equinixmetal/ironlib-docker/pull/26)

#### How can this change be tested by a PR reviewer?

Running alloy inband collector in a test server: `./alloy inband -timeout 60s --asset-id ${HARDWAREID} --asset-source serverService --publish-target serverService --trace --profile"`

So far only tested on a supermicro but I'll test it further. Still need to fix the tests that are failing. 
