### PR TITLE
[FS-539] Implement out of band bios configuration collection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/jacobweinstock/registrar v0.4.6
 	github.com/jinzhu/copier v0.3.5
-	github.com/metal-toolbox/ironlib v0.2.5
+	github.com/metal-toolbox/ironlib v0.2.6-0.20230313083928-82c470aff5e5
 	github.com/peterbourgon/ff/v3 v3.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/metal-toolbox/alloy
 go 1.19
 
 require (
-	github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230308211403-bb58254ca1a7
+	github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230308154037-6f5089bc74fe
 	github.com/bmc-toolbox/common v0.0.0-20230220061748-93ff001f4a1d
 	github.com/bombsimon/logrusr/v2 v2.0.1
 	github.com/coreos/go-oidc v2.2.1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/metal-toolbox/alloy
 go 1.19
 
 require (
-	github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20221219143242-1dbc47057ba3
-	github.com/bmc-toolbox/common v0.0.0-20221115135648-0b584f504396
+	github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230308211403-bb58254ca1a7
+	github.com/bmc-toolbox/common v0.0.0-20230220061748-93ff001f4a1d
 	github.com/bombsimon/logrusr/v2 v2.0.1
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/equinix-labs/otel-init-go v0.0.7
@@ -125,7 +125,7 @@ require (
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	gocloud.dev v0.27.0 // indirect
 	golang.org/x/crypto v0.4.0 // indirect
-	golang.org/x/exp v0.0.0-20230116083435-1de6713980de // indirect
+	golang.org/x/exp v0.0.0-20230127130021-4ca2cb1a16b7 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edY
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230308211403-bb58254ca1a7 h1:Dfk+wsdxnCo3bFkLeQrGuuyURxD0nsBse3LSe/dh2jI=
-github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230308211403-bb58254ca1a7/go.mod h1:ni0GMKsi9uNyrkRH51exh5xCg0Fs+aTtJPbbR73AaYI=
+github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230308154037-6f5089bc74fe h1:ooZMmSIjEHe5axHJoNBPWj888JiD/EXAQlwGGTgLK7w=
+github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230308154037-6f5089bc74fe/go.mod h1:ni0GMKsi9uNyrkRH51exh5xCg0Fs+aTtJPbbR73AaYI=
 github.com/bmc-toolbox/common v0.0.0-20230220061748-93ff001f4a1d h1:cQ30Wa8mhLzK1TSOG+g3FlneIsXtFgun61mmPwVPmD0=
 github.com/bmc-toolbox/common v0.0.0-20230220061748-93ff001f4a1d/go.mod h1:SY//n1PJjZfbFbmAsB6GvEKbc7UXz3d30s3kWxfJQ/c=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=

--- a/go.sum
+++ b/go.sum
@@ -252,12 +252,8 @@ github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edY
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20221219143242-1dbc47057ba3 h1:EQpdvDZgNje9/lvPlB+BLjBkeQ4cI3TrwEW589tztW0=
-github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20221219143242-1dbc47057ba3/go.mod h1:2HUSfpk9cdI69955us3orjKGlVr/SKNZg2DQZuNqsjQ=
 github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230308211403-bb58254ca1a7 h1:Dfk+wsdxnCo3bFkLeQrGuuyURxD0nsBse3LSe/dh2jI=
 github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230308211403-bb58254ca1a7/go.mod h1:ni0GMKsi9uNyrkRH51exh5xCg0Fs+aTtJPbbR73AaYI=
-github.com/bmc-toolbox/common v0.0.0-20221115135648-0b584f504396 h1:MAIYVFtt/Hnhx0Cth6T9pnLTJnZKppzi7LHue4KpPtg=
-github.com/bmc-toolbox/common v0.0.0-20221115135648-0b584f504396/go.mod h1:SY//n1PJjZfbFbmAsB6GvEKbc7UXz3d30s3kWxfJQ/c=
 github.com/bmc-toolbox/common v0.0.0-20230220061748-93ff001f4a1d h1:cQ30Wa8mhLzK1TSOG+g3FlneIsXtFgun61mmPwVPmD0=
 github.com/bmc-toolbox/common v0.0.0-20230220061748-93ff001f4a1d/go.mod h1:SY//n1PJjZfbFbmAsB6GvEKbc7UXz3d30s3kWxfJQ/c=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
@@ -1124,8 +1120,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
-github.com/metal-toolbox/ironlib v0.2.5 h1:un+QgZWYe5b9lZZbtPMspSyoK2P3a1rw+5daz7pUF7g=
-github.com/metal-toolbox/ironlib v0.2.5/go.mod h1:vywoREorRcBGmLTcJzjpPLHYDLTXLe8KazaXtLmVkFc=
+github.com/metal-toolbox/ironlib v0.2.6-0.20230313083928-82c470aff5e5 h1:HO1XnamQ2Vgncm5W5nybvVcoaFqkMQaWkDH53ljiTCo=
+github.com/metal-toolbox/ironlib v0.2.6-0.20230313083928-82c470aff5e5/go.mod h1:twp0CVQaUAZ7LAx6uZy99bGaH89zIj6b5C+kCrId9p0=
 github.com/microsoft/ApplicationInsights-Go v0.4.4/go.mod h1:fKRUseBqkw6bDiXTs3ESTiU/4YTIHsQS4W3fP2ieF4U=
 github.com/microsoft/go-mssqldb v0.17.0/go.mod h1:OkoNGhGEs8EZqchVTtochlXruEhEOaO4S0d2sB5aeGQ=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -1751,8 +1747,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20230116083435-1de6713980de h1:DBWn//IJw30uYCgERoxCg84hWtA97F4wMiKOIh00Uf0=
-golang.org/x/exp v0.0.0-20230116083435-1de6713980de/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/exp v0.0.0-20230127130021-4ca2cb1a16b7 h1:o7Ps2IYdzLRolS9/nadqeMSHpa9k8pu8u+VKBFUG7cQ=
 golang.org/x/exp v0.0.0-20230127130021-4ca2cb1a16b7/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=

--- a/go.sum
+++ b/go.sum
@@ -254,8 +254,12 @@ github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20221219143242-1dbc47057ba3 h1:EQpdvDZgNje9/lvPlB+BLjBkeQ4cI3TrwEW589tztW0=
 github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20221219143242-1dbc47057ba3/go.mod h1:2HUSfpk9cdI69955us3orjKGlVr/SKNZg2DQZuNqsjQ=
+github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230308211403-bb58254ca1a7 h1:Dfk+wsdxnCo3bFkLeQrGuuyURxD0nsBse3LSe/dh2jI=
+github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230308211403-bb58254ca1a7/go.mod h1:ni0GMKsi9uNyrkRH51exh5xCg0Fs+aTtJPbbR73AaYI=
 github.com/bmc-toolbox/common v0.0.0-20221115135648-0b584f504396 h1:MAIYVFtt/Hnhx0Cth6T9pnLTJnZKppzi7LHue4KpPtg=
 github.com/bmc-toolbox/common v0.0.0-20221115135648-0b584f504396/go.mod h1:SY//n1PJjZfbFbmAsB6GvEKbc7UXz3d30s3kWxfJQ/c=
+github.com/bmc-toolbox/common v0.0.0-20230220061748-93ff001f4a1d h1:cQ30Wa8mhLzK1TSOG+g3FlneIsXtFgun61mmPwVPmD0=
+github.com/bmc-toolbox/common v0.0.0-20230220061748-93ff001f4a1d/go.mod h1:SY//n1PJjZfbFbmAsB6GvEKbc7UXz3d30s3kWxfJQ/c=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bombsimon/logrusr/v2 v2.0.1 h1:1VgxVNQMCvjirZIYaT9JYn6sAVGVEcNtRE0y4mvaOAM=
 github.com/bombsimon/logrusr/v2 v2.0.1/go.mod h1:ByVAX+vHdLGAfdroiMg6q0zgq2FODY2lc5YJvzmOJio=
@@ -1749,6 +1753,8 @@ golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EH
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20230116083435-1de6713980de h1:DBWn//IJw30uYCgERoxCg84hWtA97F4wMiKOIh00Uf0=
 golang.org/x/exp v0.0.0-20230116083435-1de6713980de/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230127130021-4ca2cb1a16b7 h1:o7Ps2IYdzLRolS9/nadqeMSHpa9k8pu8u+VKBFUG7cQ=
+golang.org/x/exp v0.0.0-20230127130021-4ca2cb1a16b7/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/collect/outofband.go
+++ b/internal/collect/outofband.go
@@ -64,6 +64,7 @@ type oobGetter interface {
 	Open(ctx context.Context) error
 	Close(ctx context.Context) error
 	Inventory(ctx context.Context) (*common.Device, error)
+	GetBiosConfiguration(ctx context.Context) (map[string]string, error)
 }
 
 // NewOutOfBandCollector returns a instance of the OutOfBandCollector inventory collector
@@ -236,7 +237,7 @@ func (o *OutOfBandCollector) taskQueueWait(span trace.Span) {
 	}
 }
 
-// spawn runs the asset inventory collection and writes the collected inventory to the collectorCh
+// collect runs the asset inventory collection and writes the collected inventory to the collectorCh
 func (o *OutOfBandCollector) collect(ctx context.Context, asset *model.Asset) {
 	// attach child span
 	ctx, span := tracer.Start(ctx, "collect()")
@@ -289,6 +290,17 @@ func (o *OutOfBandCollector) collect(ctx context.Context, asset *model.Asset) {
 			}).Warn("BMC inventory error")
 	}
 
+	// collect bios configuration
+	err = o.bmcGetBiosConfiguration(ctx, bmc, asset)
+	if err != nil {
+		o.logger.WithFields(
+			logrus.Fields{
+				"serverID": asset.ID,
+				"IP":       asset.BMCAddress.String(),
+				"err":      err,
+			}).Warn("BMC bios configuration collection error")
+	}
+
 	// return if the context has been canceled.
 	if ctx.Err() != nil {
 		return
@@ -297,7 +309,50 @@ func (o *OutOfBandCollector) collect(ctx context.Context, asset *model.Asset) {
 	o.collectorCh <- asset
 }
 
-// bmcInventory collects inventory data from he BMC
+// bmcGetBiosConfiguration collects bios configuration data from the BMC
+// it updates the asset.BiosConfig attribute with the data collected.
+//
+// If any errors occurred in the collection, those are included in the asset.Errors attribute.
+func (o *OutOfBandCollector) bmcGetBiosConfiguration(ctx context.Context, bmc oobGetter, asset *model.Asset) error {
+	// measure BMC GetBiosConfiguration query
+	startTS := time.Now()
+
+	// attach child span
+	ctx, span := tracer.Start(ctx, "GetBiosConfiguration()")
+	defer span.End()
+
+	biosConfig, err := bmc.GetBiosConfiguration(ctx)
+	if err != nil {
+		o.logger.WithFields(
+			logrus.Fields{
+				"serverID": asset.ID,
+				"IP":       asset.BMCAddress.String(),
+				"err":      err,
+			}).Warn("error in bmc bios configuration collection")
+
+		span.SetStatus(codes.Error, " BMC GetBiosConfiguration(): "+err.Error())
+
+		// increment get bios configuration query error count metric
+		if strings.Contains(err.Error(), "no compatible System Odata IDs identified") {
+			asset.IncludeError("GetBiosConfigurationError", "redfish_incompatible: no compatible System Odata IDs identified")
+			metricIncrementBMCQueryErrorCount(asset.Vendor, asset.Model, "redfish_incompatible")
+		} else {
+			asset.IncludeError("GetBiosConfigurationError", err.Error())
+			metricIncrementBMCQueryErrorCount(asset.Vendor, asset.Model, "GetBiosConfigurationError")
+		}
+
+		return err
+	}
+
+	// measure BMC GetBiosConfiguration query time
+	metricObserveBMCQueryTimeSummary(asset.Vendor, asset.Model, "GetBiosConfiguration", startTS)
+
+	asset.BiosConfig = biosConfig
+
+	return nil
+}
+
+// bmcInventory collects inventory data from the BMC
 // it updates the asset.Inventory attribute with the data collected.
 //
 // If any errors occurred in the collection, those are included in the asset.Errors attribute.

--- a/internal/collect/outofband_test.go
+++ b/internal/collect/outofband_test.go
@@ -85,6 +85,11 @@ func Test_OutOfBandInventoryRemote(t *testing.T) {
 	// test inventory items match expected
 	assert.Equal(t, len(mockAssets), len(got))
 
+	// test asset.BiosConfig is populated
+	for _, a := range got {
+		assert.Equal(t, "bar", a.BiosConfig["foo"])
+	}
+
 	// test bmc connection was opened
 	assert.Equal(t, os.Getenv(fixtures.EnvMockBMCOpen), "true")
 

--- a/internal/fixtures/bmclib.go
+++ b/internal/fixtures/bmclib.go
@@ -37,6 +37,13 @@ func (m *MockBmclib) Inventory(ctx context.Context) (*common.Device, error) {
 	return CopyDevice(E3C246D4INL), nil
 }
 
+func (m *MockBmclib) GetBiosConfiguration(ctx context.Context) (biosConfig map[string]string, err error) {
+	biosConfig = make(map[string]string)
+	biosConfig["foo"] = "bar"
+
+	return biosConfig, nil
+}
+
 func NewMockBmclib() *MockBmclib {
 	return &MockBmclib{}
 }

--- a/internal/fixtures/device.go
+++ b/internal/fixtures/device.go
@@ -62,12 +62,15 @@ var (
 					Firmware:    nil,
 					Status:      nil,
 				},
-				ID:          "",
-				Description: "",
-				SpeedBits:   0,
-				PhysicalID:  "",
-				BusInfo:     "",
-				MacAddress:  "",
+				ID: "",
+				NICPorts: []*common.NICPort{
+					&common.NICPort{
+						SpeedBits:  0,
+						PhysicalID: "",
+						BusInfo:    "",
+						MacAddress: "",
+					},
+				},
 			},
 		},
 		Mainboard: &common.Mainboard{
@@ -170,12 +173,15 @@ var (
 						"speed":    "10Gbit/s",
 					},
 				},
-				ID:          "",
-				Description: "Ethernet interface",
-				SpeedBits:   10000000000,
-				PhysicalID:  "0",
-				BusInfo:     "pci@0000:01:00.0",
-				MacAddress:  "",
+				ID: "",
+				NICPorts: []*common.NICPort{
+					{
+						SpeedBits:  10000000000,
+						PhysicalID: "0",
+						BusInfo:    "pci@0000:01:00.0",
+						MacAddress: "",
+					},
+				},
 			},
 		},
 		Drives: []*common.Drive{
@@ -624,7 +630,7 @@ var (
 			&common.NIC{
 				Common: common.Common{
 					Oem:         false,
-					Description: "",
+					Description: "Embedded NIC 1 Port 1 Partition 1",
 					Vendor:      "",
 					Model:       "",
 					Serial:      "",
@@ -642,17 +648,20 @@ var (
 						PostCodeStatus: "",
 					},
 				},
-				ID:          "NIC.Embedded.1",
-				Description: "Embedded NIC 1 Port 1 Partition 1",
-				SpeedBits:   6,
-				PhysicalID:  "",
-				BusInfo:     "",
-				MacAddress:  "",
+				ID: "NIC.Embedded.1",
+				NICPorts: []*common.NICPort{
+					{
+						SpeedBits:  6,
+						PhysicalID: "",
+						BusInfo:    "",
+						MacAddress: "",
+					},
+				},
 			},
 			&common.NIC{
 				Common: common.Common{
 					Oem:         false,
-					Description: "",
+					Description: "NIC in Slot 3 Port 1 Partition 1",
 					Vendor:      "Intel Corporation",
 					Model:       "Intel(R) 10GbE 2P X710 Adapter",
 					Serial:      "MYFLMIT04P00HQ",
@@ -673,12 +682,15 @@ var (
 						PostCodeStatus: "",
 					},
 				},
-				ID:          "NIC.Slot.3",
-				Description: "NIC in Slot 3 Port 1 Partition 1",
-				SpeedBits:   100006,
-				PhysicalID:  "",
-				BusInfo:     "",
-				MacAddress:  "F8:F2:1E:A0:0D:E0",
+				ID: "NIC.Slot.3",
+				NICPorts: []*common.NICPort{
+					{
+						SpeedBits:  100006,
+						PhysicalID: "",
+						BusInfo:    "",
+						MacAddress: "F8:F2:1E:A0:0D:E0",
+					},
+				},
 			},
 		},
 		Drives: []*common.Drive{
@@ -1456,7 +1468,7 @@ var (
 			&common.NIC{
 				Common: common.Common{
 					Oem:         false,
-					Description: "",
+					Description: "Embedded NIC 1 Port 1 Partition 1",
 					Vendor:      "",
 					Model:       "",
 					Serial:      "",
@@ -1474,17 +1486,20 @@ var (
 						PostCodeStatus: "",
 					},
 				},
-				ID:          "NIC.Embedded.1",
-				Description: "Embedded NIC 1 Port 1 Partition 1",
-				SpeedBits:   6,
-				PhysicalID:  "",
-				BusInfo:     "",
-				MacAddress:  "",
+				ID: "NIC.Embedded.1",
+				NICPorts: []*common.NICPort{
+					{
+						SpeedBits:  6,
+						PhysicalID: "",
+						BusInfo:    "",
+						MacAddress: "",
+					},
+				},
 			},
 			&common.NIC{
 				Common: common.Common{
 					Oem:         false,
-					Description: "",
+					Description: "NIC in Slot 3 Port 1 Partition 1",
 					Vendor:      "Intel Corporation",
 					Model:       "Intel(R) 10GbE 2P X710 Adapter",
 					Serial:      "MYFLMIT04P00HQ",
@@ -1505,12 +1520,15 @@ var (
 						PostCodeStatus: "",
 					},
 				},
-				ID:          "NIC.Slot.3",
-				Description: "NIC in Slot 3 Port 1 Partition 1",
-				SpeedBits:   100006,
-				PhysicalID:  "",
-				BusInfo:     "",
-				MacAddress:  "F8:F2:1E:A0:0D:E0",
+				ID: "NIC.Slot.3",
+				NICPorts: []*common.NICPort{
+					{
+						SpeedBits:  100006,
+						PhysicalID: "",
+						BusInfo:    "",
+						MacAddress: "F8:F2:1E:A0:0D:E0",
+					},
+				},
 			},
 		},
 		Drives: []*common.Drive{

--- a/internal/publish/serverservice_attributes_test.go
+++ b/internal/publish/serverservice_attributes_test.go
@@ -432,12 +432,12 @@ func Test_ServerService_CreateUpdateServerComponents_ObjectsAdded(t *testing.T) 
 	device.Inventory.NICs = append(
 		device.Inventory.NICs,
 		&common.NIC{
-			ID:          "NEW NIC!",
-			Description: "Just added!, totally incompatible",
+			ID: "NEW NIC!",
 			Common: common.Common{
-				Vendor: "noname",
-				Model:  "noname",
-				Serial: fixtureNICSerial,
+				Vendor:      "noname",
+				Model:       "noname",
+				Serial:      fixtureNICSerial,
+				Description: "Just added!, totally incompatible",
 			},
 		},
 	)

--- a/internal/publish/serverservice_components.go
+++ b/internal/publish/serverservice_components.go
@@ -530,20 +530,22 @@ func (h *serverServicePublisher) nics(deviceVendor string, nics []*common.NIC) [
 			return nil
 		}
 
-		h.setAttributes(
-			sc,
-			&attributes{
-				Description:  c.Description,
-				ProductName:  c.ProductName,
-				Oem:          c.Oem,
-				Metadata:     c.Metadata,
-				PhysicalID:   c.PhysicalID,
-				BusInfo:      c.BusInfo,
-				MacAddress:   c.MacAddress,
-				SpeedBits:    c.SpeedBits,
-				Capabilities: c.Capabilities,
-			},
-		)
+		for _, p := range c.NICPorts {
+			h.setAttributes(
+				sc,
+				&attributes{
+					Description:  c.Description,
+					ProductName:  c.ProductName,
+					Oem:          c.Oem,
+					Metadata:     c.Metadata,
+					PhysicalID:   p.PhysicalID,
+					BusInfo:      p.BusInfo,
+					MacAddress:   p.MacAddress,
+					SpeedBits:    p.SpeedBits,
+					Capabilities: c.Capabilities,
+				},
+			)
+		}
 
 		h.setVersionedAttributes(
 			deviceVendor,


### PR DESCRIPTION
#### What does this PR do

- Updates alloy to use latest bmclib and ironlib which includes support to collect bios configuration
- Use the new bmclib method to collect bios configuration during inventory collection

#### The HW vendor this change applies to (if applicable)

- Dell

#### The HW model number, product name this change applies to (if applicable)

#### The BMC firmware and/or BIOS versions that this change applies to (if applicable)

#### What version of tooling - vendor specific or opensource does this change depend on (if applicable)

- Latest bmclib and ironlib

#### How can this change be tested by a PR reviewer?

Running alloy oob inventory collection against a dell system

```
./alloy outofband -asset-source serverService -asset-ids $asset_id -asset-source serverService --publish-target serverService --trace --profile
```