### PR TITLE
goreleaser: pass --yes to cosign when signing docker images

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -79,5 +79,6 @@ docker_signs:
       - "sign"
       - "--oidc-issuer=https://token.actions.githubusercontent.com"
       - "${artifact}"
+      - "--yes" # required on cosign 2.0.0+
     artifacts: all
     output: true


### PR DESCRIPTION
Fixes the GH actions release step from failing https://github.com/metal-toolbox/alloy/actions/runs/4512335939
