### PR TITLE
[FS-557] Split status and firmware versioned attributes into their own namespaces

### DIFF
--- a/internal/fixtures/serverservice_components_E3C246D4INL.go
+++ b/internal/fixtures/serverservice_components_E3C246D4INL.go
@@ -92,7 +92,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -894,9 +894,8 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
-						91,
 						123,
 						34,
 						102,
@@ -934,7 +933,6 @@ var (
 						34,
 						125,
 						125,
-						93,
 					},
 					Tally: 0,
 				},

--- a/internal/fixtures/serverservice_components_R6515_f0c8e4ac.go
+++ b/internal/fixtures/serverservice_components_R6515_f0c8e4ac.go
@@ -79,7 +79,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -260,7 +260,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -447,7 +447,15 @@ var (
 						34,
 						125,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -491,6 +499,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -625,6 +634,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -669,6 +679,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -803,6 +814,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -847,6 +859,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -981,6 +994,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -1025,6 +1039,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -1159,6 +1174,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -1203,6 +1219,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -1337,6 +1354,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -1381,6 +1399,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -1515,6 +1534,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -1559,6 +1579,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -1693,6 +1714,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -1737,6 +1759,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -1871,6 +1894,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -1915,6 +1939,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -2005,9 +2030,8 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
-						91,
 						123,
 						34,
 						102,
@@ -2042,7 +2066,15 @@ var (
 						50,
 						34,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -2214,9 +2246,8 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
-						91,
 						123,
 						34,
 						102,
@@ -2366,7 +2397,15 @@ var (
 						34,
 						125,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -2723,7 +2762,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -2859,7 +2898,15 @@ var (
 						34,
 						125,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -2903,6 +2950,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -3215,7 +3263,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -3351,7 +3399,15 @@ var (
 						34,
 						125,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -3395,6 +3451,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -3678,7 +3735,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -3793,7 +3850,15 @@ var (
 						34,
 						125,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -3837,6 +3902,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -4120,7 +4186,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -4235,7 +4301,15 @@ var (
 						34,
 						125,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -4279,6 +4353,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -4356,7 +4431,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -4394,7 +4469,15 @@ var (
 						68,
 						34,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -4438,6 +4521,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -4515,7 +4599,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -4553,7 +4637,15 @@ var (
 						68,
 						34,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -4597,6 +4689,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -4810,7 +4903,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -4849,7 +4942,15 @@ var (
 						50,
 						34,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -4893,6 +4994,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -4942,7 +5044,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -5028,7 +5130,15 @@ var (
 						34,
 						125,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -5070,6 +5180,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -5121,7 +5232,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -5285,7 +5396,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -5388,7 +5499,15 @@ var (
 						34,
 						125,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -5432,6 +5551,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -5494,7 +5614,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -5583,7 +5703,15 @@ var (
 						34,
 						125,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -5627,6 +5755,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -5698,7 +5827,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -5714,7 +5843,15 @@ var (
 						58,
 						123,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -5756,6 +5893,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -5827,7 +5965,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -5843,7 +5981,15 @@ var (
 						58,
 						123,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -5885,6 +6031,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -6275,6 +6422,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -6319,6 +6467,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -6509,6 +6658,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -6553,6 +6703,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -6679,6 +6830,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -6723,6 +6875,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},

--- a/internal/fixtures/serverservice_components_R6515_fc167440.go
+++ b/internal/fixtures/serverservice_components_R6515_fc167440.go
@@ -108,7 +108,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -289,7 +289,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -476,7 +476,15 @@ var (
 						34,
 						125,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -520,6 +528,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -666,6 +675,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -710,6 +720,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -856,6 +867,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -900,6 +912,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -1046,6 +1059,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -1090,6 +1104,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -1236,6 +1251,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -1280,6 +1296,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -1426,6 +1443,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -1470,6 +1488,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -1616,6 +1635,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -1660,6 +1680,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -1806,6 +1827,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -1850,6 +1872,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -1996,6 +2019,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -2040,6 +2064,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -2130,9 +2155,8 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
-						91,
 						123,
 						34,
 						102,
@@ -2167,7 +2191,15 @@ var (
 						50,
 						34,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -2339,9 +2371,8 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
-						91,
 						123,
 						34,
 						102,
@@ -2491,7 +2522,15 @@ var (
 						34,
 						125,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -2848,7 +2887,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -2984,7 +3023,15 @@ var (
 						34,
 						125,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -3028,6 +3075,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -3340,7 +3388,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -3476,7 +3524,15 @@ var (
 						34,
 						125,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -3520,6 +3576,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -3669,7 +3726,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -3685,7 +3742,15 @@ var (
 						58,
 						123,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -3729,6 +3794,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -3878,7 +3944,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -3894,7 +3960,15 @@ var (
 						58,
 						123,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -3938,6 +4012,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -4015,7 +4090,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -4053,7 +4128,15 @@ var (
 						68,
 						34,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -4097,6 +4180,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -4174,7 +4258,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -4212,7 +4296,15 @@ var (
 						68,
 						34,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -4256,6 +4348,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -4475,7 +4568,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -4514,7 +4607,15 @@ var (
 						50,
 						34,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -4558,6 +4659,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -4607,7 +4709,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -4693,7 +4795,15 @@ var (
 						34,
 						125,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -4735,6 +4845,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -4786,7 +4897,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -4950,7 +5061,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -5053,7 +5164,15 @@ var (
 						34,
 						125,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -5097,6 +5216,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -5159,7 +5279,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -5248,7 +5368,15 @@ var (
 						34,
 						125,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -5292,6 +5420,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -5363,7 +5492,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -5379,7 +5508,15 @@ var (
 						58,
 						123,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -5421,6 +5558,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -5492,7 +5630,7 @@ var (
 			},
 			VersionedAttributes: []serverservice.VersionedAttributes{
 				serverservice.VersionedAttributes{
-					Namespace: "sh.hollow.alloy.outofband.status",
+					Namespace: "sh.hollow.alloy.outofband.firmware",
 					Data: json.RawMessage{
 						123,
 						34,
@@ -5508,7 +5646,15 @@ var (
 						58,
 						123,
 						125,
-						44,
+						125,
+					},
+					Tally: 0,
+				},
+				serverservice.VersionedAttributes{
+					Namespace: "sh.hollow.alloy.outofband.status",
+					Data: json.RawMessage{
+						91,
+						123,
 						34,
 						115,
 						116,
@@ -5550,6 +5696,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -5940,6 +6087,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -5984,6 +6132,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -6174,6 +6323,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -6218,6 +6368,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},
@@ -6344,6 +6495,7 @@ var (
 				serverservice.VersionedAttributes{
 					Namespace: "sh.hollow.alloy.outofband.status",
 					Data: json.RawMessage{
+						91,
 						123,
 						34,
 						115,
@@ -6388,6 +6540,7 @@ var (
 						34,
 						125,
 						125,
+						93,
 					},
 					Tally: 0,
 				},

--- a/internal/model/serverservice.go
+++ b/internal/model/serverservice.go
@@ -49,8 +49,13 @@ func ServerComponentAttributeNS(appKind string) string {
 	return fmt.Sprintf("%s.%s.metadata", ServerServiceNSPrefix, appKind)
 }
 
-// ServerComponentVersionedAttributeNS returns the namespace server component versioned attributes are stored in.
-func ServerComponentVersionedAttributeNS(appKind string) string {
+// ServerComponentFirmwareNS returns the namespace server component firmware attributes are stored in.
+func ServerComponentFirmwareNS(appKind string) string {
+	return fmt.Sprintf("%s.%s.firmware", ServerServiceNSPrefix, appKind)
+}
+
+// ServerComponentStatusNS returns the namespace server component statuses are stored in.
+func ServerComponentStatusNS(appKind string) string {
 	return fmt.Sprintf("%s.%s.status", ServerServiceNSPrefix, appKind)
 }
 

--- a/internal/publish/serverservice.go
+++ b/internal/publish/serverservice.go
@@ -48,17 +48,18 @@ func init() {
 
 // serverServicePublisher publishes asset inventory to serverService
 type serverServicePublisher struct {
-	logger               *logrus.Entry
-	config               *model.Config
-	syncWg               *sync.WaitGroup
-	collectorCh          <-chan *model.Asset
-	termCh               <-chan os.Signal
-	workers              *workerpool.WorkerPool
-	client               *serverservice.Client
-	slugs                map[string]*serverservice.ServerComponentType
-	firmwares            map[string][]*serverservice.ComponentFirmwareVersion
-	attributeNS          string
-	versionedAttributeNS string
+	logger                       *logrus.Entry
+	config                       *model.Config
+	syncWg                       *sync.WaitGroup
+	collectorCh                  <-chan *model.Asset
+	termCh                       <-chan os.Signal
+	workers                      *workerpool.WorkerPool
+	client                       *serverservice.Client
+	slugs                        map[string]*serverservice.ServerComponentType
+	firmwares                    map[string][]*serverservice.ComponentFirmwareVersion
+	attributeNS                  string
+	firmwareVersionedAttributeNS string
+	statusVersionedAttributeNS   string
 }
 
 // NewServerServicePublisher returns a serverService publisher to submit inventory data.
@@ -71,17 +72,18 @@ func NewServerServicePublisher(ctx context.Context, alloy *app.App) (Publisher, 
 	}
 
 	p := &serverServicePublisher{
-		logger:               logger,
-		config:               alloy.Config,
-		syncWg:               alloy.SyncWg,
-		collectorCh:          alloy.CollectorCh,
-		termCh:               alloy.TermCh,
-		workers:              workerpool.New(concurrency),
-		client:               client,
-		slugs:                make(map[string]*serverservice.ServerComponentType),
-		firmwares:            make(map[string][]*serverservice.ComponentFirmwareVersion),
-		attributeNS:          model.ServerComponentAttributeNS(alloy.Config.AppKind),
-		versionedAttributeNS: model.ServerComponentVersionedAttributeNS(alloy.Config.AppKind),
+		logger:                       logger,
+		config:                       alloy.Config,
+		syncWg:                       alloy.SyncWg,
+		collectorCh:                  alloy.CollectorCh,
+		termCh:                       alloy.TermCh,
+		workers:                      workerpool.New(concurrency),
+		client:                       client,
+		slugs:                        make(map[string]*serverservice.ServerComponentType),
+		firmwares:                    make(map[string][]*serverservice.ComponentFirmwareVersion),
+		attributeNS:                  model.ServerComponentAttributeNS(alloy.Config.AppKind),
+		firmwareVersionedAttributeNS: model.ServerComponentFirmwareNS(alloy.Config.AppKind),
+		statusVersionedAttributeNS:   model.ServerComponentStatusNS(alloy.Config.AppKind),
 	}
 
 	return p, nil

--- a/internal/publish/serverservice_attributes.go
+++ b/internal/publish/serverservice_attributes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/metal-toolbox/alloy/internal/model"
 	r3diff "github.com/r3labs/diff/v3"
 	serverservice "go.hollow.sh/serverservice/pkg/api/v1"
+	"golang.org/x/exp/slices"
 )
 
 // createUpdateServerAttributes creates/updates the server serial, vendor, model attributes
@@ -351,7 +352,7 @@ func (h *serverServicePublisher) filterByAttributeNamespace(components []*server
 		components[cIdx].Attributes = attributes
 
 		for idx, versionedAttribute := range component.VersionedAttributes {
-			if versionedAttribute.Namespace == h.versionedAttributeNS {
+			if slices.Contains([]string{h.firmwareVersionedAttributeNS, h.statusVersionedAttributeNS}, versionedAttribute.Namespace) {
 				versionedAttributes = append(versionedAttributes, component.VersionedAttributes[idx])
 			}
 		}

--- a/internal/publish/serverservice_components.go
+++ b/internal/publish/serverservice_components.go
@@ -180,12 +180,20 @@ func (h *serverServicePublisher) gpus(deviceVendor string, gpus []*common.GPU) [
 			},
 		)
 
-		h.setVersionedAttributes(
+		h.setFirmwareVA(
 			deviceVendor,
 			sc,
-			&versionedAttributes{
+			&firmwareVersionedAttribute{
 				Firmware: c.Firmware,
-				Status:   c.Status,
+			},
+		)
+
+		h.setStatusVA(
+			sc,
+			[]*statusVersionedAttribute{
+				{
+					Status: c.Status,
+				},
 			},
 		)
 
@@ -224,12 +232,20 @@ func (h *serverServicePublisher) cplds(deviceVendor string, cplds []*common.CPLD
 			},
 		)
 
-		h.setVersionedAttributes(
+		h.setFirmwareVA(
 			deviceVendor,
 			sc,
-			&versionedAttributes{
+			&firmwareVersionedAttribute{
 				Firmware: c.Firmware,
-				Status:   c.Status,
+			},
+		)
+
+		h.setStatusVA(
+			sc,
+			[]*statusVersionedAttribute{
+				{
+					Status: c.Status,
+				},
 			},
 		)
 
@@ -269,12 +285,20 @@ func (h *serverServicePublisher) tpms(deviceVendor string, tpms []*common.TPM) [
 			},
 		)
 
-		h.setVersionedAttributes(
+		h.setFirmwareVA(
 			deviceVendor,
 			sc,
-			&versionedAttributes{
+			&firmwareVersionedAttribute{
 				Firmware: c.Firmware,
-				Status:   c.Status,
+			},
+		)
+
+		h.setStatusVA(
+			sc,
+			[]*statusVersionedAttribute{
+				{
+					Status: c.Status,
+				},
 			},
 		)
 
@@ -319,12 +343,20 @@ func (h *serverServicePublisher) cpus(deviceVendor string, cpus []*common.CPU) [
 			},
 		)
 
-		h.setVersionedAttributes(
+		h.setFirmwareVA(
 			deviceVendor,
 			sc,
-			&versionedAttributes{
+			&firmwareVersionedAttribute{
 				Firmware: c.Firmware,
-				Status:   c.Status,
+			},
+		)
+
+		h.setStatusVA(
+			sc,
+			[]*statusVersionedAttribute{
+				{
+					Status: c.Status,
+				},
 			},
 		)
 
@@ -382,12 +414,20 @@ func (h *serverServicePublisher) storageControllers(deviceVendor string, control
 			},
 		)
 
-		h.setVersionedAttributes(
+		h.setFirmwareVA(
 			deviceVendor,
 			sc,
-			&versionedAttributes{
+			&firmwareVersionedAttribute{
 				Firmware: c.Firmware,
-				Status:   c.Status,
+			},
+		)
+
+		h.setStatusVA(
+			sc,
+			[]*statusVersionedAttribute{
+				{
+					Status: c.Status,
+				},
 			},
 		)
 
@@ -434,12 +474,20 @@ func (h *serverServicePublisher) psus(deviceVendor string, psus []*common.PSU) [
 			},
 		)
 
-		h.setVersionedAttributes(
+		h.setFirmwareVA(
 			deviceVendor,
 			sc,
-			&versionedAttributes{
+			&firmwareVersionedAttribute{
 				Firmware: c.Firmware,
-				Status:   c.Status,
+			},
+		)
+
+		h.setStatusVA(
+			sc,
+			[]*statusVersionedAttribute{
+				{
+					Status: c.Status,
+				},
 			},
 		)
 
@@ -491,12 +539,20 @@ func (h *serverServicePublisher) drives(deviceVendor string, drives []*common.Dr
 			},
 		)
 
-		h.setVersionedAttributes(
+		h.setFirmwareVA(
 			deviceVendor,
 			sc,
-			&versionedAttributes{
+			&firmwareVersionedAttribute{
 				Firmware: c.Firmware,
-				Status:   c.Status,
+			},
+		)
+
+		h.setStatusVA(
+			sc,
+			[]*statusVersionedAttribute{
+				{
+					Status: c.Status,
+				},
 			},
 		)
 
@@ -534,12 +590,18 @@ func (h *serverServicePublisher) nics(deviceVendor string, nics []*common.NIC) [
 		nicPortAttrs := []*attributes{}
 
 		// include NIC firmware attributes
-		//
-		// NIC port attributes are populated below.
-		versionedAttrs := []*versionedAttributes{
-			{
+		h.setFirmwareVA(
+			deviceVendor,
+			sc,
+			&firmwareVersionedAttribute{
 				Firmware: c.Firmware,
-				Status:   c.Status,
+			},
+		)
+
+		// NIC port attributes are populated below.
+		statusesVA := []*statusVersionedAttribute{
+			{
+				Status: c.Status,
 			},
 		}
 
@@ -561,7 +623,7 @@ func (h *serverServicePublisher) nics(deviceVendor string, nics []*common.NIC) [
 				continue
 			}
 			// Store the NIC Port status
-			versionedAttrs = append(versionedAttrs, &versionedAttributes{
+			statusesVA = append(statusesVA, &statusVersionedAttribute{
 				NicPortStatus: &nicPortStatus{
 					ID:                   p.ID,
 					MTUSize:              p.MTUSize,
@@ -575,7 +637,7 @@ func (h *serverServicePublisher) nics(deviceVendor string, nics []*common.NIC) [
 		}
 
 		h.setAttributesList(sc, nicPortAttrs)
-		h.setVersionedAttributesList(deviceVendor, sc, versionedAttrs)
+		h.setStatusVA(sc, statusesVA)
 
 		components = append(components, sc)
 	}
@@ -627,12 +689,20 @@ func (h *serverServicePublisher) dimms(deviceVendor string, dimms []*common.Memo
 			},
 		)
 
-		h.setVersionedAttributes(
+		h.setFirmwareVA(
 			deviceVendor,
 			sc,
-			&versionedAttributes{
+			&firmwareVersionedAttribute{
 				Firmware: c.Firmware,
-				Status:   c.Status,
+			},
+		)
+
+		h.setStatusVA(
+			sc,
+			[]*statusVersionedAttribute{
+				{
+					Status: c.Status,
+				},
 			},
 		)
 
@@ -670,12 +740,20 @@ func (h *serverServicePublisher) mainboard(deviceVendor string, c *common.Mainbo
 		},
 	)
 
-	h.setVersionedAttributes(
+	h.setFirmwareVA(
 		deviceVendor,
 		sc,
-		&versionedAttributes{
+		&firmwareVersionedAttribute{
 			Firmware: c.Firmware,
-			Status:   c.Status,
+		},
+	)
+
+	h.setStatusVA(
+		sc,
+		[]*statusVersionedAttribute{
+			{
+				Status: c.Status,
+			},
 		},
 	)
 
@@ -714,12 +792,20 @@ func (h *serverServicePublisher) enclosures(deviceVendor string, enclosures []*c
 			},
 		)
 
-		h.setVersionedAttributes(
+		h.setFirmwareVA(
 			deviceVendor,
 			sc,
-			&versionedAttributes{
+			&firmwareVersionedAttribute{
 				Firmware: c.Firmware,
-				Status:   c.Status,
+			},
+		)
+
+		h.setStatusVA(
+			sc,
+			[]*statusVersionedAttribute{
+				{
+					Status: c.Status,
+				},
 			},
 		)
 
@@ -756,12 +842,20 @@ func (h *serverServicePublisher) bmc(deviceVendor string, c *common.BMC) *server
 		},
 	)
 
-	h.setVersionedAttributes(
+	h.setFirmwareVA(
 		deviceVendor,
 		sc,
-		&versionedAttributes{
+		&firmwareVersionedAttribute{
 			Firmware: c.Firmware,
-			Status:   c.Status,
+		},
+	)
+
+	h.setStatusVA(
+		sc,
+		[]*statusVersionedAttribute{
+			{
+				Status: c.Status,
+			},
 		},
 	)
 
@@ -797,12 +891,20 @@ func (h *serverServicePublisher) bios(deviceVendor string, c *common.BIOS) *serv
 		},
 	)
 
-	h.setVersionedAttributes(
+	h.setFirmwareVA(
 		deviceVendor,
 		sc,
-		&versionedAttributes{
+		&firmwareVersionedAttribute{
 			Firmware: c.Firmware,
-			Status:   c.Status,
+		},
+	)
+
+	h.setStatusVA(
+		sc,
+		[]*statusVersionedAttribute{
+			{
+				Status: c.Status,
+			},
 		},
 	)
 
@@ -860,14 +962,18 @@ type nicPortStatus struct {
 	AutoSpeedNegotiation bool   `json:"autospeednegotiation,omitempty"`
 }
 
-// versionedAttributes are component attributes to be versioned in server service
-type versionedAttributes struct {
-	Firmware      *common.Firmware `json:"firmware,omitempty"`
-	Status        *common.Status   `json:"status,omitempty"`
-	NicPortStatus *nicPortStatus   `json:"nic_port_status,omitempty"`
-	UUID          *uuid.UUID       `json:"uuid,omitempty"` // UUID references firmware UUID identified in serverservice based on component/device attributes.
-	SmartStatus   string           `json:"smart_status,omitempty"`
-	Vendor        string           `json:"vendor,omitempty"`
+// firmwareVersionedAttribute holds component firmware information.
+type firmwareVersionedAttribute struct {
+	Firmware *common.Firmware `json:"firmware,omitempty"`
+	UUID     *uuid.UUID       `json:"uuid,omitempty"` // UUID references firmware UUID identified in serverservice based on component/device attributes.
+	Vendor   string           `json:"vendor,omitempty"`
+}
+
+// statusVersionedAttribute holds component status information.
+type statusVersionedAttribute struct {
+	Status        *common.Status `json:"status,omitempty"`
+	NicPortStatus *nicPortStatus `json:"nic_port_status,omitempty"`
+	SmartStatus   string         `json:"smart_status,omitempty"`
 }
 
 // setAttributesList updates the given component with the given list of attributes.
@@ -971,28 +1077,19 @@ func (h *serverServicePublisher) setAttributes(component *serverservice.ServerCo
 	)
 }
 
-// setVersionedAttributesList updates the given component with given list of versioned attributes.
+// setStatusVA updates the given component with given list of statusVersionedAttributes.
 //
 // versioned attributes per component in serverservice have a unique constraint on
-// the component ID, namespace, created_at values.
+// the component ID, namespace values.
 //
-// so if this method is called twice for the same component, namespace, that versioned attribute will be ignored.
-func (h *serverServicePublisher) setVersionedAttributesList(deviceVendor string, component *serverservice.ServerComponent, vattrs []*versionedAttributes) {
-	if len(vattrs) == 0 {
+// so if this method is called twice for the same component, namespace, that statusVersionedAttribute will be ignored.
+func (h *serverServicePublisher) setStatusVA(component *serverservice.ServerComponent, statusesVA []*statusVersionedAttribute) {
+	if len(statusesVA) == 0 {
 		return
 	}
 
-	// enrich firmware data
-	for _, vattr := range vattrs {
-		if vattr.Firmware == nil {
-			continue
-		}
-
-		h.enrichFirmwareData(deviceVendor, component.Vendor, vattr)
-	}
-
 	// convert versioned attributes to raw json
-	data, err := json.Marshal(vattrs)
+	data, err := json.Marshal(statusesVA)
 	if err != nil {
 		h.logger.WithFields(
 			logrus.Fields{
@@ -1002,70 +1099,8 @@ func (h *serverServicePublisher) setVersionedAttributesList(deviceVendor string,
 			}).Warn("error in conversion of versioned attributes to raw data")
 	}
 
-	// skip empty json data containing just the braces `{}`
-	min := 2
-	if len(data) == min {
-		return
-	}
-
-	if component.VersionedAttributes == nil {
-		component.VersionedAttributes = []serverservice.VersionedAttributes{}
-	} else {
-		// versioned attributes per component in serverservice have a unique constraint on
-		// the component ID, namespace, created_at values.
-		//
-		// so here we ignore the new attribute with the same namespace, if one already exists.
-		for _, existingVA := range component.VersionedAttributes {
-			if existingVA.Namespace != h.versionedAttributeNS {
-				continue
-			}
-
-			h.logger.WithFields(
-				logrus.Fields{
-					"slug":      component.ComponentTypeSlug,
-					"kind":      fmt.Sprintf("%T", data),
-					"namespace": h.versionedAttributeNS,
-				}).Warn("duplicate versioned attribute on component dropped - this was unexpected.")
-
-			return
-		}
-	}
-
-	component.VersionedAttributes = append(
-		component.VersionedAttributes,
-		serverservice.VersionedAttributes{
-			Namespace: h.versionedAttributeNS,
-			Data:      data,
-		},
-	)
-}
-
-// setVersionedAttributes updates a component with single versioned attribute.
-//
-// versioned attributes per component in serverservice have a unique constraint on
-// the component ID, namespace, created_at values.
-//
-// so if this method is called twice for the same component, namespace, that versioned attribute will be ignored,
-// the caller should invoke setVersionedAttributesList() instead.
-func (h *serverServicePublisher) setVersionedAttributes(deviceVendor string, component *serverservice.ServerComponent, vattr *versionedAttributes) {
-	// add FirmwareData
-	if vattr.Firmware != nil {
-		h.enrichFirmwareData(deviceVendor, component.Vendor, vattr)
-	}
-
-	// convert versioned attributes to raw json
-	data, err := json.Marshal(vattr)
-	if err != nil {
-		h.logger.WithFields(
-			logrus.Fields{
-				"slug": component.ComponentTypeSlug,
-				"kind": fmt.Sprintf("%T", data),
-				"err":  err,
-			}).Warn("error in conversion of versioned attributes to raw data")
-	}
-
-	// skip empty json data containing just the braces `{}`
-	min := 2
+	// skip empty json data containing just the braces `[{}]`
+	min := 4
 	if len(data) == min {
 		return
 	}
@@ -1074,7 +1109,7 @@ func (h *serverServicePublisher) setVersionedAttributes(deviceVendor string, com
 		component.VersionedAttributes = []serverservice.VersionedAttributes{}
 	} else {
 		for _, existingVA := range component.VersionedAttributes {
-			if existingVA.Namespace != h.versionedAttributeNS {
+			if existingVA.Namespace != h.statusVersionedAttributeNS {
 				continue
 			}
 
@@ -1082,7 +1117,7 @@ func (h *serverServicePublisher) setVersionedAttributes(deviceVendor string, com
 				logrus.Fields{
 					"slug":      component.ComponentTypeSlug,
 					"kind":      fmt.Sprintf("%T", data),
-					"namespace": h.versionedAttributeNS,
+					"namespace": h.statusVersionedAttributeNS,
 				}).Warn("duplicate versioned attribute on component dropped.")
 
 			return
@@ -1092,7 +1127,64 @@ func (h *serverServicePublisher) setVersionedAttributes(deviceVendor string, com
 	component.VersionedAttributes = append(
 		component.VersionedAttributes,
 		serverservice.VersionedAttributes{
-			Namespace: h.versionedAttributeNS,
+			Namespace: h.statusVersionedAttributeNS,
+			Data:      data,
+		},
+	)
+}
+
+// setFirmwareVA updates a component with single firmwareVersionedAttribute.
+//
+// versioned attributes per component in serverservice have a unique constraint on
+// the component ID, namespace values.
+//
+// so if this method is called twice for the same component, namespace, that versioned attribute will be ignored.
+func (h *serverServicePublisher) setFirmwareVA(deviceVendor string, component *serverservice.ServerComponent, fwVA *firmwareVersionedAttribute) {
+	// add FirmwareData
+	if fwVA.Firmware != nil {
+		h.enrichFirmwareData(deviceVendor, component.Vendor, fwVA)
+	}
+
+	// convert versioned attributes to raw json
+	data, err := json.Marshal(fwVA)
+	if err != nil {
+		h.logger.WithFields(
+			logrus.Fields{
+				"slug": component.ComponentTypeSlug,
+				"kind": fmt.Sprintf("%T", data),
+				"err":  err,
+			}).Warn("error in conversion of versioned attributes to raw data")
+	}
+
+	// skip empty json data containing just the braces `{}`
+	min := 2
+	if len(data) == min {
+		return
+	}
+
+	if component.VersionedAttributes == nil {
+		component.VersionedAttributes = []serverservice.VersionedAttributes{}
+	} else {
+		for _, existingVA := range component.VersionedAttributes {
+			if existingVA.Namespace != h.firmwareVersionedAttributeNS {
+				continue
+			}
+
+			h.logger.WithFields(
+				logrus.Fields{
+					"slug":      component.ComponentTypeSlug,
+					"kind":      fmt.Sprintf("%T", data),
+					"namespace": h.firmwareVersionedAttributeNS,
+				}).Warn("duplicate versioned attribute on component dropped.")
+
+			return
+		}
+	}
+
+	component.VersionedAttributes = append(
+		component.VersionedAttributes,
+		serverservice.VersionedAttributes{
+			Namespace: h.firmwareVersionedAttributeNS,
 			Data:      data,
 		},
 	)
@@ -1101,7 +1193,7 @@ func (h *serverServicePublisher) setVersionedAttributes(deviceVendor string, com
 // enrichFirmwareData queries ServerService for the firmware version and try to find a match.
 //
 // the given versionedAttribute object is updated to include the firmware vendor and the serverservice firmware UUID.
-func (h *serverServicePublisher) enrichFirmwareData(deviceVendor, componentVendor string, vattr *versionedAttributes) {
+func (h *serverServicePublisher) enrichFirmwareData(deviceVendor, componentVendor string, vattr *firmwareVersionedAttribute) {
 	// Check in the cache if we have a match by vendor + version
 	for _, fw := range h.firmwares[componentVendor] {
 		if strings.EqualFold(fw.Version, vattr.Firmware.Installed) {

--- a/internal/publish/serverservice_components_test.go
+++ b/internal/publish/serverservice_components_test.go
@@ -44,7 +44,8 @@ func Test_ToComponentSlice(t *testing.T) {
 	p.logger = logrus.NewEntry(logrus.New())
 	p.slugs = fixtures.ServerServiceSlugMap()
 	p.attributeNS = model.ServerComponentAttributeNS(model.AppKindOutOfBand)
-	p.versionedAttributeNS = model.ServerComponentVersionedAttributeNS(model.AppKindOutOfBand)
+	p.firmwareVersionedAttributeNS = model.ServerComponentFirmwareNS(model.AppKindOutOfBand)
+	p.statusVersionedAttributeNS = model.ServerComponentStatusNS(model.AppKindOutOfBand)
 
 	testcases := []struct {
 		name     string

--- a/internal/publish/serverservice_test.go
+++ b/internal/publish/serverservice_test.go
@@ -26,7 +26,7 @@ func assertComponentAttributes(t *testing.T, obj *serverservice.ServerComponent,
 func rawVersionAttributeFirmwareEquals(t *testing.T, expectedVersion string, rawVA []byte) bool {
 	t.Helper()
 
-	va := &versionedAttributes{}
+	va := &firmwareVersionedAttribute{}
 
 	err := json.Unmarshal(rawVA, va)
 	if err != nil {
@@ -47,7 +47,7 @@ func Test_ServerServiceChangeList(t *testing.T) {
 		expectedAdd     int
 		expectedRemove  int
 		slug            string // the component slug
-		vaUpdates       *versionedAttributes
+		vaUpdates       *firmwareVersionedAttribute
 		aUpdates        *attributes
 		addComponent    bool // adds a new component into the new slice before comparison
 		removeComponent bool // removes a component from the new slice
@@ -71,7 +71,7 @@ func Test_ServerServiceChangeList(t *testing.T) {
 			0,
 			0,
 			common.SlugBIOS,
-			&versionedAttributes{Firmware: &common.Firmware{Installed: "2.2.6"}},
+			&firmwareVersionedAttribute{Firmware: &common.Firmware{Installed: "2.2.6"}},
 			nil,
 			false,
 			false,
@@ -83,7 +83,7 @@ func Test_ServerServiceChangeList(t *testing.T) {
 			1,
 			0,
 			common.SlugNIC,
-			&versionedAttributes{Firmware: &common.Firmware{Installed: "1.3.3"}},
+			&firmwareVersionedAttribute{Firmware: &common.Firmware{Installed: "1.3.3"}},
 			nil,
 			true,
 			false,


### PR DESCRIPTION
#### What does this PR do
Split status and firmware versioned attributes into their own namespaces. The firmware versioned attribute data field is kept as a single object while the status versioned attribute data field becomes an array since some components, like NICs, may contains multiple statuses for each nicport.

#### How can this change be tested by a PR reviewer?

`./alloy outofband --asset-source serverService  --publish-target serverService --asset-ids <>`