### PR TITLE
Update alloy inband docker img to ironlib v0.2.10

### DIFF
--- a/Dockerfile.inband
+++ b/Dockerfile.inband
@@ -1,4 +1,4 @@
-ARG IRONLIB_IMAGE=ghcr.io/metal-toolbox/ironlib:v0.2.6
+ARG IRONLIB_IMAGE=ghcr.io/metal-toolbox/ironlib:v0.2.10
 FROM $IRONLIB_IMAGE
 
 COPY alloy /usr/sbin/alloy


### PR DESCRIPTION
#### What does this PR do

Updates the alloy inband docker image to use base ironlib v0.2.10

