### PR TITLE
Dockerfile.inband: bump ironlib image

### DIFF
--- a/Dockerfile.inband
+++ b/Dockerfile.inband
@@ -1,4 +1,4 @@
-ARG IRONLIB_IMAGE=ghcr.io/metal-toolbox/ironlib:v0.2.10
+ARG IRONLIB_IMAGE=ghcr.io/metal-toolbox/ironlib:v0.2.11
 FROM $IRONLIB_IMAGE
 
 COPY alloy /usr/sbin/alloy


### PR DESCRIPTION
#### What does this PR do

Updates ironlib image to latest to fix a few trivy scan vulnerabilities
