### PR TITLE
latest ironlib image to include fixes for python vuln

### DIFF
--- a/Dockerfile.inband
+++ b/Dockerfile.inband
@@ -1,4 +1,4 @@
-ARG IRONLIB_IMAGE=ghcr.io/metal-toolbox/ironlib:v0.2.11
+ARG IRONLIB_IMAGE=ghcr.io/metal-toolbox/ironlib:v0.2.12
 FROM $IRONLIB_IMAGE
 
 COPY alloy /usr/sbin/alloy


### PR DESCRIPTION
Another attempt to fix this vulnerability,

https://avd.aquasec.com/nvd/cve-2023-24329

now confirmed its fixed in ironlib image v0.2.12
https://github.com/metal-toolbox/ironlib/actions/runs/6039251758/job/16387471880#step:7:210

which includes the updated python version python3-3.9.16-1.el9_2.1.x86_64
