### PR TITLE
bk: build inband image only if its a v0/v1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 steps:
   - trigger: "alloy-inband"
-    if: build.branch == "main" || build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+[-staging]*\$/
+    if: build.branch == "main" || build.tag =~ /^v[0-1]+\.[0-9]+\.[0-9]+/
     build:
       env:
         ALLOY_TAG: "${BUILDKITE_TAG}"


### PR DESCRIPTION
#### What does this PR do
Limits alloy inband image builds to v0/v1, until v2 is ready for an inband image release.