### PR TITLE
ci/release: fix error - go mod tidy: exit status 2; output: go: unknown subcommand "mod"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20"
       -
         name: install cosign
         uses: sigstore/cosign-installer@main
@@ -44,4 +44,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_EXPERIMENTAL: 1
-          GOVERSION: 1.20
+          GOVERSION: "1.20"


### PR DESCRIPTION
The Go 1.20 version must be quoted in CI config or we end up with Go 1.2 being installed, which has no go mod support.


