### PR TITLE
FS-963 Fix duplicate message publish on success and fix lint issue G601

### DIFF
--- a/internal/store/serverservice/components.go
+++ b/internal/store/serverservice/components.go
@@ -1167,15 +1167,23 @@ func (r *Store) enrichFirmwareData(deviceVendor, componentVendor string, vattr *
 	// Check in the cache if we have a match by vendor + version
 	for _, fw := range r.firmwares[componentVendor] {
 		if strings.EqualFold(fw.Version, vattr.Firmware.Installed) {
+			fwUUID := fw.UUID
+
 			vattr.Vendor = fw.Vendor
-			vattr.UUID = &fw.UUID
+			vattr.UUID = &fwUUID
+
+			return
 		}
 	}
 
 	for _, fw := range r.firmwares[deviceVendor] {
 		if strings.EqualFold(fw.Version, vattr.Firmware.Installed) {
+			fwUUID := fw.UUID
+
 			vattr.Vendor = fw.Vendor
-			vattr.UUID = &fw.UUID
+			vattr.UUID = &fwUUID
+
+			return
 		}
 	}
 }


### PR DESCRIPTION
#### What does this PR do

- Fix an issue where duplicate "success" messages for firmware inventory are showing up in Slack.
- Fix a lint issue encountered when trying to run unit tests.