### PR TITLE
Vc/version attributes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,8 +5,6 @@ service:
 
 linters-settings:
   govet:
-    enable:
-      - fieldalignment
     auto-fix: true
     check-shadowing: true
     settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,8 +45,6 @@ linters-settings:
       - wrapperFunc
   gofumpt:
     extra-rules: true
-  wsl:
-    auto-fix: true
 
 linters:
   enable:
@@ -73,7 +71,6 @@ linters:
     - noctx
     - stylecheck
     - whitespace
-    - wsl
     - gosec
   enable-all: false
   disable-all: true

--- a/internal/store/serverservice/attributes.go
+++ b/internal/store/serverservice/attributes.go
@@ -195,8 +195,6 @@ func (r *Store) createUpdateServerBIOSConfiguration(ctx context.Context, serverI
 	return err
 }
 
-// createUpdateServerMetadataAttributes creates/updates metadata attributes of a server
-//
 // nolint:gocyclo // (joel) theres a bunch of validation going on here, I'll split the method out if theres more to come.
 func (r *Store) createUpdateServerBMCErrorAttributes(ctx context.Context, serverID uuid.UUID, current *serverserviceapi.Attributes, asset *model.Asset) error {
 	// 1. no errors reported, none currently present

--- a/internal/store/serverservice/attributes.go
+++ b/internal/store/serverservice/attributes.go
@@ -17,6 +17,10 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+const (
+	uefiVariablesKey = "uefi-variables"
+)
+
 // createUpdateServerAttributes creates/updates the server serial, vendor, model attributes
 func (r *Store) createUpdateServerAttributes(ctx context.Context, server *serverserviceapi.Server, asset *model.Asset) error {
 	// device vendor data
@@ -72,7 +76,7 @@ func (r *Store) publishUEFIVars(ctx context.Context, serverID uuid.UUID, asset *
 		return nil
 	}
 
-	vars, exists := asset.Inventory.Metadata["uefi-variables"]
+	vars, exists := asset.Inventory.Metadata[uefiVariablesKey]
 	if !exists {
 		return nil
 	}
@@ -143,6 +147,29 @@ func vendorDataUpdate(newData, currentData map[string]string) map[string]string 
 	return currentData
 }
 
+// mustFilterAssetMetadata processes the asset inventory metadata to filter out fields we'll turn into versioned attributes (e.g. UEFIVariables)
+func mustFilterAssetMetadata(inventory map[string]string) json.RawMessage {
+	excludedKeys := map[string]struct{}{
+		uefiVariablesKey: {},
+	}
+
+	filtered := make(map[string]string)
+
+	for k, v := range inventory {
+		if _, ok := excludedKeys[k]; ok {
+			continue
+		}
+		filtered[k] = v
+	}
+
+	byt, err := json.Marshal(filtered)
+	if err != nil {
+		panic("serializing metadata string map")
+	}
+
+	return byt
+}
+
 // createUpdateServerMetadataAttributes creates/updates metadata attributes of a server
 func (r *Store) createUpdateServerMetadataAttributes(ctx context.Context, serverID uuid.UUID, asset *model.Asset) error {
 	// no metadata reported in inventory from device
@@ -150,11 +177,13 @@ func (r *Store) createUpdateServerMetadataAttributes(ctx context.Context, server
 		return nil
 	}
 
-	// marshal metadata from device
-	metadata, err := json.Marshal(asset.Inventory.Metadata)
-	if err != nil {
-		return err
+	// update when metadata differs
+	if helpers.MapsAreEqual(asset.Metadata, asset.Inventory.Metadata) {
+		return nil
 	}
+
+	// marshal metadata from device
+	metadata := mustFilterAssetMetadata(asset.Inventory.Metadata)
 
 	attribute := serverserviceapi.Attributes{
 		Namespace: serverMetadataAttributeNS,
@@ -163,17 +192,12 @@ func (r *Store) createUpdateServerMetadataAttributes(ctx context.Context, server
 
 	// current asset metadata has no attributes set, create
 	if len(asset.Metadata) == 0 {
-		_, err = r.CreateAttributes(ctx, serverID, attribute)
+		_, err := r.CreateAttributes(ctx, serverID, attribute)
 		return err
 	}
 
-	// update when metadata differs
-	if helpers.MapsAreEqual(asset.Metadata, asset.Inventory.Metadata) {
-		return nil
-	}
-
 	// update vendor, model attributes
-	_, err = r.UpdateAttributes(ctx, serverID, serverMetadataAttributeNS, metadata)
+	_, err := r.UpdateAttributes(ctx, serverID, serverMetadataAttributeNS, metadata)
 
 	return err
 }

--- a/internal/store/serverservice/attributes_test.go
+++ b/internal/store/serverservice/attributes_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/metal-toolbox/alloy/internal/model"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	serverserviceapi "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
@@ -936,4 +937,27 @@ func Test_ServerService_CreateUpdateServerBMCErrorAttributes_Updated(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestMetadataFilter(t *testing.T) {
+	t.Parallel()
+	clean := map[string]string{
+		"foo": "bar",
+		"baz": "quux",
+	}
+
+	dirty := map[string]string{
+		"foo":            "bar",
+		"baz":            "quux",
+		"uefi-variables": "uhoh-nogood",
+	}
+
+	exp, err := json.Marshal(clean)
+	require.NoError(t, err, "prerequisite setup")
+
+	got := mustFilterAssetMetadata(clean)
+	require.Equal(t, json.RawMessage(exp), got, "clean doesn't serialize properly")
+
+	got = mustFilterAssetMetadata(dirty)
+	require.Equal(t, json.RawMessage(exp), got, "dirty doesn't serialize properly")
 }


### PR DESCRIPTION
Make sure that if we have metadata that exists currently on the server record, we walk a path that updates the server record's attributes instead of inserting them, as `serverservice` won't automatically handle an `upsert` here.

We also remove the `fieldalignment` linter here, which should not be on by default. The runtime penalty of a mis-aligned struct is not relevant at this point.