### PR TITLE
Update Dockerfile.inband for new ironlib image

### DIFF
--- a/Dockerfile.inband
+++ b/Dockerfile.inband
@@ -1,4 +1,4 @@
-ARG IRONLIB_IMAGE=ghcr.io/metal-toolbox/ironlib:v0.2.15
+ARG IRONLIB_IMAGE=ghcr.io/metal-toolbox/ironlib:v0.2.17
 FROM $IRONLIB_IMAGE
 
 COPY alloy /usr/sbin/alloy


### PR DESCRIPTION
Ironlib v0.2.17 uses our version of Flashrom

