### PR TITLE
fix metadata updates

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -25,10 +25,6 @@ var (
 	ErrInventoryCollect = errors.New("error collecting inventory data")
 )
 
-func init() {
-
-}
-
 // DeviceCollector holds attributes to collect inventory, bios configuration data from a single device.
 type DeviceCollector struct {
 	queryor    device.Queryor

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/goleak"
 )
 
+// XXX: Warning, this test might be flaky.
 func Test_Collect_Concurrent(t *testing.T) {
 	ignorefunc := "go.opencensus.io/stats/view.(*worker).start"
 	defer goleak.VerifyNone(t, goleak.IgnoreTopFunction(ignorefunc))

--- a/internal/store/serverservice/components_test.go
+++ b/internal/store/serverservice/components_test.go
@@ -41,7 +41,7 @@ func Test_ToComponentSlice(t *testing.T) {
 
 	mock := httptest.NewServer(handler)
 	p := testStoreInstance(t, mock.URL)
-	p.logger = logrus.NewEntry(logrus.New())
+	p.logger = logrus.New()
 	p.slugs = fixtures.ServerServiceSlugMap()
 	p.attributeNS = serverComponentAttributeNS(model.AppKindOutOfBand)
 	p.firmwareVersionedAttributeNS = serverComponentFirmwareNS(model.AppKindOutOfBand)

--- a/internal/store/serverservice/helpers.go
+++ b/internal/store/serverservice/helpers.go
@@ -30,7 +30,7 @@ var (
 // TODO move this under an interface
 
 // NewServerServiceClient instantiates and returns a serverService client
-func NewServerServiceClient(ctx context.Context, cfg *app.ServerserviceOptions, logger *logrus.Entry) (*serverserviceapi.Client, error) {
+func NewServerServiceClient(ctx context.Context, cfg *app.ServerserviceOptions, logger *logrus.Logger) (*serverserviceapi.Client, error) {
 	if cfg == nil {
 		return nil, errors.Wrap(ErrConfig, "configuration is nil")
 	}
@@ -43,7 +43,7 @@ func NewServerServiceClient(ctx context.Context, cfg *app.ServerserviceOptions, 
 }
 
 // returns a serverservice retryable client with Otel
-func newServerserviceClientWithOtel(cfg *app.ServerserviceOptions, endpoint string, logger *logrus.Entry) (*serverserviceapi.Client, error) {
+func newServerserviceClientWithOtel(cfg *app.ServerserviceOptions, endpoint string, logger *logrus.Logger) (*serverserviceapi.Client, error) {
 	if cfg == nil {
 		return nil, errors.Wrap(ErrConfig, "configuration is nil")
 	}
@@ -69,13 +69,6 @@ func newServerserviceClientWithOtel(cfg *app.ServerserviceOptions, endpoint stri
 	// set retryable HTTP client to be the otel http client to collect telemetry
 	retryableClient.HTTPClient = otelhttp.DefaultClient
 
-	// disable default debug logging on the retryable client
-	if logger.Level < logrus.DebugLevel {
-		retryableClient.Logger = nil
-	} else {
-		retryableClient.Logger = logger
-	}
-
 	// requests taking longer than timeout value should be canceled.
 	client := retryableClient.StandardClient()
 	client.Timeout = timeout
@@ -88,23 +81,18 @@ func newServerserviceClientWithOtel(cfg *app.ServerserviceOptions, endpoint stri
 }
 
 // returns a serverservice retryable http client with Otel and Oauth wrapped in
-func newServerserviceClientWithOAuthOtel(ctx context.Context, cfg *app.ServerserviceOptions, endpoint string, logger *logrus.Entry) (*serverserviceapi.Client, error) {
+func newServerserviceClientWithOAuthOtel(ctx context.Context, cfg *app.ServerserviceOptions, endpoint string, logger *logrus.Logger) (*serverserviceapi.Client, error) {
 	if cfg == nil {
 		return nil, errors.Wrap(ErrConfig, "configuration is nil")
 	}
+
+	logger.Info("serverservice client ctor")
 
 	// init retryable http client
 	retryableClient := retryablehttp.NewClient()
 
 	// set retryable HTTP client to be the otel http client to collect telemetry
 	retryableClient.HTTPClient = otelhttp.DefaultClient
-
-	// disable default debug logging on the retryable client
-	if logger.Level < logrus.DebugLevel {
-		retryableClient.Logger = nil
-	} else {
-		retryableClient.Logger = logger
-	}
 
 	// setup oidc provider
 	provider, err := oidc.NewProvider(ctx, cfg.OidcIssuerEndpoint)


### PR DESCRIPTION
Account for cases where a metadata field exists but has no data. In this case the record must be updated instead of created.