### PR TITLE
[FS-1337]Alloy Inband sends inventory to CIS

### DIFF
--- a/cmd/inband.go
+++ b/cmd/inband.go
@@ -99,7 +99,7 @@ func collectInband(ctx context.Context, cfg *app.Configuration, logger *logrus.L
 		return
 	}
 
-	if err := c.CollectInband(ctx, &model.Asset{ID: assetID}, outputStdout); err != nil {
+	if err := c.CollectInbandAndUploadToCIS(ctx, assetID, outputStdout); err != nil {
 		logger.Error(err)
 		return
 	}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -128,14 +128,14 @@ func (c *DeviceCollector) CollectOutofbandAndUploadToCIS(ctx context.Context, as
 	return nil
 }
 
-// CollectInband querys inventory and bios configuration data for a device through the host OS
+// CollectInbandAndUploadToCIS querys inventory and bios configuration data for a device through the host OS
 // this expects Alloy is running within the alloy-inband docker image based on ironlib.
-func (c *DeviceCollector) CollectInband(ctx context.Context, asset *model.Asset, outputStdout bool) error {
+func (c *DeviceCollector) CollectInbandAndUploadToCIS(ctx context.Context, assetID string, outputStdout bool) error {
 	var errs error
 
 	// XXX: This is duplicative! The asset is fetched again prior to updating serverservice.
 	// fetch existing asset information from inventory
-	existing, err := c.repository.AssetByID(ctx, asset.ID, c.kind == model.AppKindOutOfBand)
+	existing, err := c.repository.AssetByID(ctx, assetID, c.kind == model.AppKindOutOfBand)
 	if err != nil {
 		c.log.WithError(err).Warn("getting asset by ID")
 		errs = multierror.Append(errs, err)
@@ -170,7 +170,7 @@ func (c *DeviceCollector) CollectInband(ctx context.Context, asset *model.Asset,
 		return c.prettyPrintJSON(cisInventory)
 	}
 
-	if _, err = c.cisClient.UpdateInbandInventory(ctx, asset.ID, cisInventory); err != nil {
+	if _, err = c.cisClient.UpdateInbandInventory(ctx, assetID, cisInventory); err != nil {
 		errs = multierror.Append(errs, err)
 
 		return errs


### PR DESCRIPTION
This PR update the inband process in Alloy to interact with Component Inventory Service.

Most works have been finished by the previous PR when supporting outofband to CIS. This PR cleanup the `Asset` type usage and verify it works in sandbox.

Tested with sandbox, logs in CIS:
```
inv = &{Common:{Oem:false Description: Vendor:supermicro Model:X11SCH-F Serial:S440931X1409128 ProductName: LogicalName: PCIVendorID: PCIProductID: Capabilities:[] Metadata:map[] Firmware:<nil> Status:<nil>} HardwareType: Chassis: BIOS:0xc0006da1a0 BMC:0xc0006da270 Mainboard:0xc0006da340 CPLDs:[0xc0004d80c0] TPMs:[0xc0006da410] GPUs:[] CPUs:[0xc000392400] Memory:[0xc000484900 0xc000484a20 0xc000484b40 0xc000484c60] NICs:[0xc000420380] Drives:[0xc000411520 0xc000411860 0xc0006031e0 0xc000603380] StorageControllers:[0xc00057c3c0] PSUs:[0xc0006da5b0 0xc0006da680] Enclosures:[]}[GIN-debug]
```
