### PR TITLE
Delete buildkite files

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,0 @@
-steps:
-  - trigger: "alloy-inband"
-    if: build.branch == "main" || build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+[-staging]*\$/
-    build:
-      env:
-        ALLOY_TAG: "${BUILDKITE_TAG}"
-        ALLOY_COMMIT: "${BUILDKITE_COMMIT}"
-        ALLOY_BRANCH: "${BUILDKITE_BRANCH}"


### PR DESCRIPTION
#### What does this PR do

Deletes the buildkite pipeline file that was used to build internal/private images. Those builds have been super seceded by a different method for a little while now.
