### PR TITLE
FS-1316; Add preload for latency fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/jacobweinstock/registrar v0.4.7
 	github.com/jeremywohl/flatten v1.0.1
 	github.com/jinzhu/copier v0.3.5
-	github.com/metal-toolbox/fleetdb v1.18.5
+	github.com/metal-toolbox/fleetdb v1.18.6-0.20240617210817-833f87cf7c69
 	github.com/metal-toolbox/ironlib v0.2.15
 	github.com/metal-toolbox/rivets v1.0.4
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -535,8 +535,8 @@ github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4
 github.com/mattn/go-sqlite3 v2.0.1+incompatible h1:xQ15muvnzGBHpIpdrNi1DA5x0+TcBZzsIDwmw9uTHzw=
 github.com/mattn/go-sqlite3 v2.0.1+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/metal-toolbox/fleetdb v1.18.5 h1:xFY6SzThdPMWtTnb8cNE0Dpa+kCMFcZdM72MITW530g=
-github.com/metal-toolbox/fleetdb v1.18.5/go.mod h1:RRQt0MZQApuQKp4gUrE+ZwPVqvI6qhMbpakGBlxPJZc=
+github.com/metal-toolbox/fleetdb v1.18.6-0.20240617210817-833f87cf7c69 h1:iWW59TeWTSi3wQXfIeEWaJod2I4dBUx2LYup0tEW+QA=
+github.com/metal-toolbox/fleetdb v1.18.6-0.20240617210817-833f87cf7c69/go.mod h1:RRQt0MZQApuQKp4gUrE+ZwPVqvI6qhMbpakGBlxPJZc=
 github.com/metal-toolbox/ironlib v0.2.15 h1:0uLmUnS7GgRZVwTOGJ+uyUlDEkSzoD+BYvZme9/C5tk=
 github.com/metal-toolbox/ironlib v0.2.15/go.mod h1:QRGRb//lV7LR2yDIe/zmXTFYGKhltQsRol05QlHzfBw=
 github.com/metal-toolbox/rivets v1.0.4 h1:BFvlYWsN+5Zb2JS+oJJBDtaQ94M5x2Llf6kmwi+Byjo=

--- a/internal/store/fleetdb/fleetdb.go
+++ b/internal/store/fleetdb/fleetdb.go
@@ -142,8 +142,9 @@ func (r *Store) AssetsByOffsetLimit(ctx context.Context, offset, limit int) (ass
 			},
 		},
 		PaginationParams: &fleetdbapi.PaginationParams{
-			Limit: limit,
-			Page:  offset,
+			Limit:   limit,
+			Page:    offset,
+			Preload: true,
 		},
 	}
 


### PR DESCRIPTION
Fixing issues with fleetdb's latency will require us to specify PaginationParams.Preload for pagination when getting lists of items. This is to prevent unnecessary loading of data that is not needed.

In order to do that, we need alloy to reference fleetDB over serverservice API. So this will also remove many references to serverservice.