### PR TITLE
FS-1518: update bmc-toolbox/common

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230825151635-6cf01686c513
-	github.com/bmc-toolbox/common v0.0.0-20231204194243-7bcbccab7116
+	github.com/bmc-toolbox/common v0.0.0-20240510143200-3db7cecbb5a6
 	github.com/bombsimon/logrusr/v2 v2.0.1
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/equinix-labs/otel-init-go v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230825151635-6cf01686c513 h1:FArNt6XfHzD55b67tw7UwMPL9Uz/6/bQ+weI1kPNbbU=
 github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230825151635-6cf01686c513/go.mod h1:a3Ra0ce/LV3wAj7AHuphlHNTx5Sg67iQqtLGr1zoqio=
-github.com/bmc-toolbox/common v0.0.0-20231204194243-7bcbccab7116 h1:gqWn/cMjryKoUfITx2vRHrRHTvd9fQ+zKPwWsmMIrK4=
-github.com/bmc-toolbox/common v0.0.0-20231204194243-7bcbccab7116/go.mod h1:SY//n1PJjZfbFbmAsB6GvEKbc7UXz3d30s3kWxfJQ/c=
+github.com/bmc-toolbox/common v0.0.0-20240510143200-3db7cecbb5a6 h1:qJJDtxYKk/sMfF6F3hVAcM+KDpN1H58gNWpdtaQys0o=
+github.com/bmc-toolbox/common v0.0.0-20240510143200-3db7cecbb5a6/go.mod h1:SY//n1PJjZfbFbmAsB6GvEKbc7UXz3d30s3kWxfJQ/c=
 github.com/bombsimon/logrusr/v2 v2.0.1 h1:1VgxVNQMCvjirZIYaT9JYn6sAVGVEcNtRE0y4mvaOAM=
 github.com/bombsimon/logrusr/v2 v2.0.1/go.mod h1:ByVAX+vHdLGAfdroiMg6q0zgq2FODY2lc5YJvzmOJio=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=


### PR DESCRIPTION
#### What does this PR do
Update the version of `bmc-toolbox/common` to account for SMC `x12sth-sys`

#### How can this change be tested by a PR reviewer?
Build alloy at this SHA. Reserve a `m3.small.x86.v1 (w/iGPU)`. Enroll into the sandbox and follow the inventory. The correct output should be: 
```
➜  mctl git:(main) ✗ ./mctl --config ~/.mctl/kind.yaml get server -s abcdf392-1aed-4070-b33c-3394319f4416
[
  {
    "updated": "2024-06-11T19:35:17.898328Z",
    "id": "abcdf392-1aed-4070-b33c-3394319f4416",
    "facility": "sandbox",
    "name": "abcdf392-1aed-4070-b33c-3394319f4416",
    "bmc_address": "10.197.132.37",
    "vendor": "supermicro",
    "model": "x12sth-sys",
    "serial": "E895731X4500534"
  }
]```

Note that the model is tracked as `x12sth-sys` and not the motherboard model of `SYS-510T-MR2-EI018`.