### PR TITLE
Inband Docker will run alloy-inband by default

### DIFF
--- a/Dockerfile.inband
+++ b/Dockerfile.inband
@@ -3,5 +3,7 @@ FROM $IRONLIB_IMAGE
 
 COPY alloy /usr/sbin/alloy
 RUN chmod +x /usr/sbin/alloy
+COPY task.sh task.sh
+RUN chmod +x ./task.sh
 
-ENTRYPOINT ["/bin/bash", "-l", "-c"]
+ENTRYPOINT ["./task.sh"]

--- a/task.sh
+++ b/task.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo "Welcome to Alloy Inband container"
+
+alloy inband
+
+cat <<"EOF" > /statedir/cleanup.sh
+#!/usr/bin/env bash
+echo "This is the cleanup script.sh"
+for i in {1..10}
+do
+  echo $i
+  sleep 1
+done
+reboot
+EOF
+chmod +x /statedir/cleanup.sh
+
+echo "task.sh is now finished, cleanup.sh will reboot after 10s"


### PR DESCRIPTION
#### What does this PR do

Add inband flasher execution to Dockerfile

#### How can this change be tested by a PR reviewer?

Build the docker container and run it with ` -v /tmp/statedir:/statedir` to see that alloy has been run and the `cleanup.sh` script has been created