### PR TITLE
Add logs to track alloy inband success

### DIFF
--- a/internal/device/inband/inband.go
+++ b/internal/device/inband/inband.go
@@ -71,12 +71,15 @@ func (i *Queryor) BiosConfiguration(ctx context.Context, asset *model.Asset) err
 		}
 	}
 
+	i.logger.Info("inband: GetBIOSConfiguration launching...")
 	biosConfig, err := i.deviceManager.GetBIOSConfiguration(ctx)
 	if err != nil {
+		i.logger.WithFields(logrus.Fields{"err": err}).Error("inband: GetBIOSConfiguration error")
 		return err
 	}
 
 	asset.BiosConfig = biosConfig
 
+	i.logger.Info("inband: GetBIOSConfiguration success")
 	return nil
 }

--- a/internal/device/inband/inband.go
+++ b/internal/device/inband/inband.go
@@ -38,8 +38,10 @@ func (i *Queryor) Inventory(ctx context.Context, asset *model.Asset) error {
 		}
 	}
 
+	i.logger.Info("inband: GetInventory launching...")
 	device, err := i.deviceManager.GetInventory(ctx)
 	if err != nil {
+		i.logger.WithFields(logrus.Fields{"err": err}).Error("inband: GetInventory error")
 		return err
 	}
 
@@ -52,6 +54,7 @@ func (i *Queryor) Inventory(ctx context.Context, asset *model.Asset) error {
 	asset.Model = "unknown"
 	asset.Serial = "unknown"
 
+	i.logger.Info("inband: GetInventory success")
 	return nil
 }
 


### PR DESCRIPTION
Add logs that use the loggerEntry so that we can track correctly without relying on deviceManager use of the logger
